### PR TITLE
Add NoOp client provider to allow no-operation scaling evaluation.

### DIFF
--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -14,6 +14,7 @@ The Chemtrail server can be configured by supplying either CLI flags or using en
 * `--log-level` (string: "info") - Change the level used for logging.
 * `--log-use-color` (bool: false) - Use ANSI colors in logging output.
 * `--provider-aws-asg-enabled` (bool: false) - Enable the AWS AutoScaling Group client provider.
+* `--provider-noop-enabled` (bool: true) - Enable the NoOp client provider.
 * `--telemetry-statsd-address` (string: "") - Specifies the address of a statsd server to forward metrics to.
 * `--telemetry-statsite-address` (string: "") - Specifies the address of a statsite server to forward metrics data to.
 * `--tls-cert-key-path` (string: "") - Path to the TLS certificate key for the Chemtrail server.
@@ -60,6 +61,10 @@ The Consul client environment variables documentation can be found on the [Consu
 ## Provider Configuration
 
 In order to make scaling requests to backend providers, configuration is required providing authentication amongst others. Below are specific details of the minimum requirement for each provider, and links if available to more in-depth documentation.
+
+### NoOp
+
+The NoOp provider is ideal when first introducing Chemtrail to your environment, or when making configuration changes. The NoOp provider will not enact scaling changes, but will log at INFO level intended behaviour and predicted actions.
 
 ### Amazon Web Services
 

--- a/pkg/config/server/provider.go
+++ b/pkg/config/server/provider.go
@@ -7,15 +7,18 @@ import (
 
 const (
 	configKeyProviderAWSASGEnabled = "provider-aws-asg-enabled"
+	configKeyProviderNoOpEnabled   = "provider-noop-enabled"
 )
 
 type ProviderConfig struct {
 	AWSASG bool
+	NoOp   bool
 }
 
 func GetProviderConfig() *ProviderConfig {
 	return &ProviderConfig{
 		AWSASG: viper.GetBool(configKeyProviderAWSASGEnabled),
+		NoOp:   viper.GetBool(configKeyProviderNoOpEnabled),
 	}
 }
 
@@ -28,6 +31,18 @@ func RegisterProviderConfig(cmd *cobra.Command) {
 			longOpt      = "provider-aws-asg-enabled"
 			defaultValue = false
 			description  = "Enable the AWS AutoScaling Group client provider"
+		)
+
+		flags.Bool(longOpt, defaultValue, description)
+		_ = viper.BindPFlag(key, flags.Lookup(longOpt))
+		viper.SetDefault(key, defaultValue)
+	}
+	{
+		const (
+			key          = configKeyProviderNoOpEnabled
+			longOpt      = "provider-noop-enabled"
+			defaultValue = true
+			description  = "Enable the NoOp client provider"
 		)
 
 		flags.Bool(longOpt, defaultValue, description)

--- a/pkg/scale/provider/no-op/no-op.go
+++ b/pkg/scale/provider/no-op/no-op.go
@@ -1,0 +1,65 @@
+package noop
+
+import (
+	"github.com/gofrs/uuid"
+	"github.com/jrasell/chemtrail/pkg/helper"
+	"github.com/jrasell/chemtrail/pkg/scale/provider"
+	"github.com/jrasell/chemtrail/pkg/state"
+	"github.com/rs/zerolog"
+)
+
+// ClientProvider implements the provider.ClientProvider interface.
+type ClientProvider struct {
+	log       zerolog.Logger
+	eventChan chan *state.EventMessage
+}
+
+// NewNoOpProvider creates a new log notification client scaling provider.
+func NewNoOpProvider(log zerolog.Logger, eventChan chan *state.EventMessage) provider.ClientProvider {
+	return &ClientProvider{
+		log:       log.With().Str("provider", state.NoOpClientProvider.String()).Logger(),
+		eventChan: eventChan,
+	}
+}
+
+// Name satisfies the provider.ClientProvider Name interface function.
+func (a *ClientProvider) Name() string { return state.NoOpClientProvider.String() }
+
+// ScaleIn satisfies the provider.ClientProvider ScaleIn interface function.
+func (a *ClientProvider) ScaleIn(req *state.ScalingRequest, _ string) error {
+	return a.notifyWrapper(req)
+}
+
+// ScaleOut satisfies the provider.ClientProvider ScaleOut interface function.
+func (a *ClientProvider) ScaleOut(req *state.ScalingRequest) error {
+	return a.notifyWrapper(req)
+}
+
+func (a *ClientProvider) notifyWrapper(req *state.ScalingRequest) error {
+	a.sendScaleLogMessage(req)
+	a.sendEvent(req.ID)
+	return nil
+}
+
+// sendScaleLogMessage is responsible for sending the notification message containing the scaling
+// request information.
+func (a *ClientProvider) sendScaleLogMessage(req *state.ScalingRequest) {
+	a.log.Info().
+		Str("id", req.ID.String()).
+		Str("direction", req.Direction.String()).
+		Str("target-node", req.TargetNodeID).
+		Object("policy", req.Policy).
+		Msg("no-op log notification of scaling activity")
+}
+
+// sendEvent sends a scaling event to be stored tracking the successful log notification. This
+// allows Chemtrail to run essentially in noop mode, while still going through the entire cycle of
+// a scaling action.
+func (a *ClientProvider) sendEvent(id uuid.UUID) {
+	a.eventChan <- &state.EventMessage{
+		ID:        id,
+		Timestamp: helper.GenerateEventTimestamp(),
+		Source:    a.Name(),
+		Message:   "successfully triggered log notification",
+	}
+}

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jrasell/chemtrail/pkg/helper"
 	"github.com/jrasell/chemtrail/pkg/scale/provider"
 	aws_asg "github.com/jrasell/chemtrail/pkg/scale/provider/aws-asg"
+	noop "github.com/jrasell/chemtrail/pkg/scale/provider/no-op"
 	"github.com/jrasell/chemtrail/pkg/scale/resource"
 	"github.com/jrasell/chemtrail/pkg/state"
 	"github.com/pkg/errors"
@@ -70,6 +71,11 @@ func NewScaleBackend(cfg *BackendConfig) Scale {
 		b.clientProvider[state.AWSAutoScaling] = aws_asg.NewAWSASGProvider(b.logger, b.eventChan)
 	}
 	b.logger.Debug().Msg("successfully setup AWS AutoScaling provider")
+
+	if cfg.Provider.NoOp {
+		b.clientProvider[state.NoOpClientProvider] = noop.NewNoOpProvider(b.logger, b.eventChan)
+		b.logger.Debug().Msg("successfully setup notify log provider")
+	}
 
 	// Start the event handler.
 	go b.eventUpdateHandler()
@@ -159,8 +165,11 @@ func (b *Backend) invokeScaling(req *state.ScalingRequest) error {
 		}
 		req.TargetNodeID = node.ID
 
-		if err := b.removeNodeFromCluster(req.TargetNodeID, req.ID); err != nil {
-			return err
+		// If we are using the NoOp provider, we should not remove the node from the cluster.
+		if req.Policy.Provider != state.NoOpClientProvider {
+			if err := b.removeNodeFromCluster(req.TargetNodeID, req.ID); err != nil {
+				return err
+			}
 		}
 
 		target, err := b.identifyProviderTarget(req)
@@ -178,6 +187,8 @@ func (b *Backend) identifyProviderTarget(req *state.ScalingRequest) (string, err
 	switch req.Policy.Provider {
 	case state.AWSAutoScaling:
 		return b.nodeIDToAWSInstanceID(req.TargetNodeID, req.ID)
+	case state.NoOpClientProvider:
+		return req.TargetNodeID, nil
 	default:
 		return "", errors.Errorf("unsupported provider: %s", req.Policy.Provider.String())
 	}

--- a/pkg/state/policy_test.go
+++ b/pkg/state/policy_test.go
@@ -18,6 +18,11 @@ func TestClientProvider_String(t *testing.T) {
 			expectedOutput:      "aws-autoscaling",
 			name:                "AWS autoscaling provider",
 		},
+		{
+			inputClientProvider: NoOpClientProvider,
+			expectedOutput:      "no-op",
+			name:                "no-op provider",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -41,6 +46,11 @@ func TestClientProvider_Validate(t *testing.T) {
 			name:                "AWS autoscaling provider",
 		},
 		{
+			inputClientProvider: NoOpClientProvider,
+			expectedOutput:      nil,
+			name:                "no-op provider",
+		},
+		{
 			inputClientProvider: fakeProvider,
 			expectedOutput:      errors.New("unsupported client provider \"fake\""),
 			name:                "invalid scaling provider",
@@ -49,6 +59,66 @@ func TestClientProvider_Validate(t *testing.T) {
 
 	for _, tc := range testCases {
 		actualOutput := tc.inputClientProvider.Validate()
+		if tc.expectedOutput == nil {
+			assert.Nil(t, actualOutput, tc.name)
+		} else {
+			assert.EqualError(t, actualOutput, tc.expectedOutput.Error(), tc.name)
+		}
+	}
+}
+
+func TestComparisonAction_String(t *testing.T) {
+	testCases := []struct {
+		inputComparisonAction ComparisonAction
+		expectedOutput        string
+		name                  string
+	}{
+		{
+			inputComparisonAction: ActionScaleIn,
+			expectedOutput:        "scale-in",
+			name:                  "scale in comparison action",
+		},
+		{
+			inputComparisonAction: ActionScaleOut,
+			expectedOutput:        "scale-out",
+			name:                  "scale out comparison action",
+		},
+	}
+
+	for _, tc := range testCases {
+		actualOutput := tc.inputComparisonAction.String()
+		assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+	}
+}
+
+func TestComparisonAction_Validate(t *testing.T) {
+
+	const fakeAction ComparisonAction = "fake"
+
+	testCases := []struct {
+		inputComparisonAction ComparisonAction
+		expectedOutput        error
+		name                  string
+	}{
+		{
+			inputComparisonAction: ActionScaleIn,
+			expectedOutput:        nil,
+			name:                  "scale-in",
+		},
+		{
+			inputComparisonAction: ActionScaleOut,
+			expectedOutput:        nil,
+			name:                  "scale-out",
+		},
+		{
+			inputComparisonAction: fakeAction,
+			expectedOutput:        errors.New("Action \"fake\" is not a valid option"),
+			name:                  "invalid comparison action",
+		},
+	}
+
+	for _, tc := range testCases {
+		actualOutput := tc.inputComparisonAction.Validate()
 		if tc.expectedOutput == nil {
 			assert.Nil(t, actualOutput, tc.name)
 		} else {


### PR DESCRIPTION
When initially implementing Chemtrail within an environment, it is
normal for users to be wary of the impacts and changes that will be
made. The NoOp provider solves this by allowing Chemtrail to
perform all its checks and calculations without altering the state
of the Nomad cluster. Chemtrail will even go through its event
cycle which will provide operators with great information.

closes #13 