### PR TITLE
Do not log AWS ASG provider setup when it is not enabled.

### DIFF
--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -68,8 +68,8 @@ func NewScaleBackend(cfg *BackendConfig) Scale {
 	// If the AWS provider is enabled, configure the scaling backend.
 	if cfg.Provider.AWSASG {
 		b.clientProvider[state.AWSAutoScaling] = aws_asg.NewAWSASGProvider(b.logger, b.eventChan)
+		b.logger.Debug().Msg("successfully setup AWS AutoScaling provider")
 	}
-	b.logger.Debug().Msg("successfully setup AWS AutoScaling provider")
 
 	// Start the event handler.
 	go b.eventUpdateHandler()


### PR DESCRIPTION
closes #19 