### PR TITLE
Fix panic when node is running an old version of the Nomad client.

### DIFF
--- a/pkg/scale/resource/nodes_test.go
+++ b/pkg/scale/resource/nodes_test.go
@@ -419,6 +419,20 @@ func Test_updateHandler_getNodeAllocatableResources(t *testing.T) {
 			expectedOutput: &resources{cpu: 5182, memory: 975},
 			name:           "no reserved CPU but reserved memory resources",
 		},
+		{
+			inputNode: &api.Node{
+				Resources: &api.Resources{
+					CPU:      intToPointer(5182),
+					MemoryMB: intToPointer(985),
+				},
+				Reserved: &api.Resources{
+					CPU:      intToPointer(0),
+					MemoryMB: intToPointer(0),
+				},
+			},
+			expectedOutput: &resources{cpu: 5182, memory: 985},
+			name:           "gh-26 older version of Nomad",
+		},
 	}
 	uh := &updateHandler{}
 


### PR DESCRIPTION
Since v0.9.0 the Nomad node API uses the NodeResources and
ReservedResources fields to track the nodes available resource for
running work. Chemtrail was blindly assuming these existed which
meant it would panic when attempting to handle a node running a
version of Nomad pre-0.9.0. This change adds compatibility and
checks that ensure Chemtrail works with versions either side of
this change without panics.

closes #26 