### PR TITLE
fix(cmd): add support for env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jrasell/chemtrail/cmd/system"
 	"github.com/jrasell/chemtrail/pkg/build"
 	clientCfg "github.com/jrasell/chemtrail/pkg/config/client"
+	envCfg "github.com/jrasell/chemtrail/pkg/config/env"
 	"github.com/sean-/sysexits"
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,7 @@ client nodes based on demand.
 		Version: build.GetVersion(),
 	}
 
+	envCfg.RegisterCobra(rootCmd)
 	clientCfg.RegisterConfig(rootCmd)
 
 	if err := registerCommands(rootCmd); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  -->

**What type of PR is this?**
Fix

**What this PR does / why we need it**:
Viper AutomaticEnv was not called. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
